### PR TITLE
Add support for Elaborated type   > Represents a type that was referred to using an elaborated type keyword, e.g., `struct S`, or via a qualified name, e.g.,` N::M::type`, or both.

### DIFF
--- a/lib/dynamic_clang.js
+++ b/lib/dynamic_clang.js
@@ -459,6 +459,7 @@ exports.CONSTANTS = {
         '111': 'CXType_FunctionProto',
         '112': 'CXType_ConstantArray',
         '113': 'CXType_Vector',
+        '119': 'CXType_Elaborated',
         CXType_Invalid: 0,
         CXType_Unexposed: 1,
         CXType_Void: 2,
@@ -504,7 +505,8 @@ exports.CONSTANTS = {
         CXType_FunctionNoProto: 110,
         CXType_FunctionProto: 111,
         CXType_ConstantArray: 112,
-        CXType_Vector: 113
+        CXType_Vector: 113,
+        CXType_Elaborated: 119
     },
     CXCallingConv: {
         '0': 'CXCallingConv_Default',
@@ -1063,6 +1065,7 @@ exports.libclang = new FFI.Library('libclang', {
     clang_getNumElements: [ref.types.longlong, [CXType]],
     clang_getArrayElementType: [CXType, [CXType]],
     clang_getArraySize: [ref.types.longlong, [CXType]],
+    clang_Type_getNamedType: [CXType, [CXType]],
     clang_isVirtualBase: [ref.types.uint32, [CXCursor]],
     clang_getCXXAccessSpecifier: [ref.types.uint32, [CXCursor]],
     clang_getNumOverloadedDecls: [ref.types.uint32, [CXCursor]],

--- a/lib/type.js
+++ b/lib/type.js
@@ -100,6 +100,12 @@ var Type = function (instance) {
     }
   });
 
+  Object.defineProperty(this, 'namedType', {
+    get: function () {
+      return new Type(lib.clang_Type_getNamedType(self._instance));
+    }
+  });
+
   this.getArg = function (arg) {
     return new Type(lib.clang_getArgType(self._instance, arg));
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,6 +135,15 @@
         "ref": "1"
       }
     },
+    "ref-union": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ref-union/-/ref-union-1.0.1.tgz",
+      "integrity": "sha1-OiOX+GLx51Fx1ocmj0Oz8Xcp8SA=",
+      "requires": {
+        "debug": "2",
+        "ref": "1"
+      }
+    },
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,144 @@
+{
+  "name": "libclang",
+  "version": "0.0.11",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "array-index": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
+      "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
+      "requires": {
+        "debug": "^2.2.0",
+        "es6-symbol": "^3.0.2"
+      }
+    },
+    "bindings": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+        }
+      }
+    },
+    "ffi": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ffi/-/ffi-2.3.0.tgz",
+      "integrity": "sha512-vkPA9Hf9CVuQ5HeMZykYvrZF2QNJ/iKGLkyDkisBnoOOFeFXZQhUPxBARPBIZMJVulvBI2R+jgofW03gyPpJcQ==",
+      "requires": {
+        "bindings": "~1.2.0",
+        "debug": "2",
+        "nan": "2",
+        "ref": "1",
+        "ref-struct": "1"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "ref": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ref/-/ref-1.3.5.tgz",
+      "integrity": "sha512-2cBCniTtxcGUjDpvFfVpw323a83/0RLSGJJY5l5lcomZWhYpU2cuLdsvYqMixvsdLJ9+sTdzEkju8J8ZHDM2nA==",
+      "requires": {
+        "bindings": "1",
+        "debug": "2",
+        "nan": "2"
+      }
+    },
+    "ref-array": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ref-array/-/ref-array-1.2.0.tgz",
+      "integrity": "sha1-u6hwFS1O4KvtFCGwYjkvCwGEKQw=",
+      "requires": {
+        "array-index": "1",
+        "debug": "2",
+        "ref": "1"
+      }
+    },
+    "ref-struct": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ref-struct/-/ref-struct-1.1.0.tgz",
+      "integrity": "sha1-XV7mWtQc78Olxf60BYcmHkee3BM=",
+      "requires": {
+        "debug": "2",
+        "ref": "1"
+      }
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ffi": "",
     "ref": "",
     "ref-array": "",
-    "ref-struct": ""
+    "ref-struct": "",
+    "ref-union": ""
   }
 }


### PR DESCRIPTION
- Supporting Elaborated types allows for a greatly expanded library generation.
- Can be used by `ffi-generate` (with Elaborated type support) to regenerate the `lib/dynamic_clang.js`; see the `llvm-clang-6.0` branch.

See

- https://clang.llvm.org/doxygen/classclang_1_1ElaboratedType.html
- https://github.com/joelpurra/node-libclang/tree/llvm-clang-6.0
- https://github.com/joelpurra/node-ffi-generate/tree/support-elaborated-type